### PR TITLE
Initialize client term to undefined value

### DIFF
--- a/src/lib/client.c
+++ b/src/lib/client.c
@@ -4,6 +4,7 @@ void clvRoomClientInit(ClvRoomClient* self, Clog log)
 {
     self->log = log;
     self->leader = 0xff;
+    self->term = 0xffff;
 }
 
 ClvRoomClientPingResult clvRoomClientOnPing(


### PR DESCRIPTION
`self-term` was uninitialized and defaulted to `0`, which caused
```
  if (pingResponse.term == self->term) {
        return result;
    }
 ```
 to always be true when the server sends the first term, thus never triggering the first leader change.